### PR TITLE
Don't assign if there's already an assignee

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -32,6 +32,9 @@ class PullRequest
   end
 
   def needs_assigning?
+    # Already has an assignee
+    return false if @payload["assignee"]
+
     # When adding label "for-review"
     label_changes = @payload.dig("changes", "labels")
 


### PR DESCRIPTION
This is a temporary work-around. There's [an issue](https://gitlab.com/gitlab-org/gitlab-ce/issues/45757) with GitLab payloads. The "work-around" for this (albeit not ideal) is to only assign if there are no assignees.